### PR TITLE
Add 'icon' and 'iconPath' to ForecastHourly json

### DIFF
--- a/usr/local/bin/dwd-mosmix
+++ b/usr/local/bin/dwd-mosmix
@@ -1187,7 +1187,7 @@ class DwdMosmix(object):
                 with open(fn,"w") as file:
                     file.write(s)
     
-    def dump(self, placemark, days, recs3hr, timesteps, daynights, issue, dryrun):
+    def dump(self, placemark, days, recs3hr, timesteps, daynights, issue, dryrun, lang='de'):
         fn = os.path.join(self.target_path,'forecast-'+placemark['id']+'.json')
         with open(fn,"w") as file:
             hours = []
@@ -1195,6 +1195,14 @@ class DwdMosmix(object):
                 hour = {'timestamp':int(val*0.001),'night':daynights[idx]}
                 for ii in placemark['Forecast']:
                     hour[ii] = placemark['Forecast'][ii][idx]
+
+                    wwcode = get_ww([placemark['Forecast']['ww'][idx]],placemark['Forecast']['Neff'][idx],daynights[idx])
+                    icon = self.icon_pth + '/' + wwcode[self.iconset]
+                    if self.iconset == 6: icon += ('n' if night else '') + '.png'
+
+                    hour['icon'] = icon
+                    hour['icontitle'] = wwcode[2] if lang == 'en' else wwcode[1]
+
                 hours.append(hour)
             x = {
                 'Issuer':issue.get('Issuer'),
@@ -2005,7 +2013,7 @@ class DwdMosmix(object):
         if 'json' in output:
             if self.verbose:
                 loginf('json')
-            self.dump(placemark,days,recs3hr,timesteps,daynights,issue,dryrun)
+            self.dump(placemark,days,recs3hr,timesteps,daynights,issue,dryrun,lang=lang)
             
         if 'belchertown' in output:
             if self.verbose:

--- a/usr/local/bin/dwd-mosmix
+++ b/usr/local/bin/dwd-mosmix
@@ -1196,12 +1196,12 @@ class DwdMosmix(object):
                 for ii in placemark['Forecast']:
                     hour[ii] = placemark['Forecast'][ii][idx]
 
-                    wwcode = get_ww([placemark['Forecast']['ww'][idx]],placemark['Forecast']['Neff'][idx],daynights[idx])
-                    icon = self.icon_pth + '/' + wwcode[self.iconset]
-                    if self.iconset == 6: icon += ('n' if night else '') + '.png'
+                wwcode = get_ww([placemark['Forecast']['ww'][idx]],placemark['Forecast']['Neff'][idx],daynights[idx])
+                icon = self.icon_pth + '/' + wwcode[self.iconset]
+                if self.iconset == 6: icon += ('n' if night else '') + '.png'
 
-                    hour['icon'] = icon
-                    hour['icontitle'] = wwcode[2] if lang == 'en' else wwcode[1]
+                hour['icon'] = icon
+                hour['icontitle'] = wwcode[2] if lang == 'en' else wwcode[1]
 
                 hours.append(hour)
             x = {


### PR DESCRIPTION
Currently, in the json dump, the props `icon` and `iconPath` are only included for `ForecastDaily` and `Forecast3hr`, but not `ForecastHourly`. This PR adds these two props also for `ForecastHourly`.