### PR TITLE
fix ValueError: could not convert string to float: 'dwd'

### DIFF
--- a/bin/user/dwd.py
+++ b/bin/user/dwd.py
@@ -690,7 +690,12 @@ class DWDservice(StdService):
         stations = poi_dict.get('stations',site_dict)
         for station in stations.sections:
             station_dict = weeutil.config.accumulateLeaves(stations[station])
-            station_dict['iconset'] = station_dict.get('icon_set',self.iconset)
+            station_dict['iconset'] = self.iconset
+            iconset = station_dict.get('icon_set')
+            if iconset is not None:
+                station_dict['iconset'] = self.iconset
+                if iconset=='dwd': station_dict['iconset'] = 5
+                if iconset=='aeris': station_dict['iconset'] = 6
             self._create_poi_thread(station, station, station_dict)
             
         # https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/
@@ -698,7 +703,12 @@ class DWDservice(StdService):
         stations = cdc_dict.get('stations',site_dict)
         for station in stations.sections:
             station_dict = weeutil.config.accumulateLeaves(stations[station])
-            station_dict['iconset'] = station_dict.get('icon_set',self.iconset)
+            station_dict['iconset'] = self.iconset
+            iconset = station_dict.get('icon_set')
+            if iconset is not None:
+                station_dict['iconset'] = self.iconset
+                if iconset=='dwd': station_dict['iconset'] = 5
+                if iconset=='aeris': station_dict['iconset'] = 6
             self._create_cdc_thread(station, station, station_dict)
         
         if  __name__!='__main__':

--- a/bin/user/dwd.py
+++ b/bin/user/dwd.py
@@ -694,6 +694,7 @@ class DWDservice(StdService):
             iconset = station_dict.get('icon_set')
             if iconset is not None:
                 station_dict['iconset'] = self.iconset
+                if iconset=='belchertown': station_dict['iconset'] = 4
                 if iconset=='dwd': station_dict['iconset'] = 5
                 if iconset=='aeris': station_dict['iconset'] = 6
             self._create_poi_thread(station, station, station_dict)
@@ -707,6 +708,7 @@ class DWDservice(StdService):
             iconset = station_dict.get('icon_set')
             if iconset is not None:
                 station_dict['iconset'] = self.iconset
+                if iconset=='belchertown': station_dict['iconset'] = 4
                 if iconset=='dwd': station_dict['iconset'] = 5
                 if iconset=='aeris': station_dict['iconset'] = 6
             self._create_cdc_thread(station, station, station_dict)


### PR DESCRIPTION
Hallo, Du kannst Dir das ja mal ansehen, ich hatte nach [c642c23](https://github.com/roe-dl/weewx-DWD/commit/c642c232cde131138b12ee6e43e3461774159eec) folgenden Fehler:

```
Traceback (most recent call last):
  File "/home/weewx/bin/weeutil/weeutil.py", line 1514, in to_int
    return int(x) if x is not None else None
ValueError: invalid literal for int() with base 10: 'dwd'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/weewx/bin/wee_reports", line 149, in <module>
    main()
  File "/home/weewx/bin/wee_reports", line 113, in main
    engine = weewx.engine.DummyEngine(config_dict)
  File "/home/weewx/bin/weewx/engine.py", line 93, in __init__
    self.loadServices(config_dict)
  File "/home/weewx/bin/weewx/engine.py", line 161, in loadServices
    obj = weeutil.weeutil.get_object(svc)(self, config_dict)
  File "/home/weewx/bin/user/dwd.py", line 694, in __init__
    self._create_poi_thread(station, station, station_dict)
  File "/home/weewx/bin/user/dwd.py", line 714, in _create_poi_thread
    self.threads[thread_name]['thread'] = DWDPOIthread(thread_name,
  File "/home/weewx/bin/user/dwd.py", line 264, in __init__
    self.iconset = weeutil.weeutil.to_int(iconset)
  File "/home/weewx/bin/weeutil/weeutil.py", line 1517, in to_int
    return int(float(x))
ValueError: could not convert string to float: 'dwd'
```

Grüße
Henry